### PR TITLE
bump CI deps and enable KVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,32 +6,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Nix
+      uses: cachix/install-nix-action@v23
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
-    - uses: cachix/cachix-action@v12
+    - name: Cache on Cachix
+      uses: cachix/cachix-action@v12
       with:
         name: flake-programs-sqlite
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: cache build result
+    - name: Cache build result on GitHub
       uses: actions/cache@v3
       with:
         path: updater.bundle
         key: ${{ runner.os }}-bundle-${{ hashFiles('**/flake.lock') }}-${{ hashFiles('**/*.nix') }}-${{ hashFiles('**/*.nim*') }}
 
-    - name: build and bundle
+    - name: Build and Bundle
       run: |
            nix build .#updater
            nix bundle -o updater.bundle.lnk .#packages.x86_64-linux.updater && cp $(readlink updater.bundle.lnk) updater.bundle && chmod u+w updater.bundle
 
-    - name: smoke test
+    - name: Smoke test
       run: |
            echo {} > ${{ runner.temp }}/sources.json
            nix run .#updater -- --dir:${{ runner.temp }} --channel:https://releases.nixos.org/nixos/20.03/nixos-20.03.2400.ff1b66eaea4
            cat ${{ runner.temp }}/sources.json
            [ `nix eval --impure nixpkgs#lib.importJSON --apply "x : (x ${{ runner.temp }}/sources.json).ff1b66eaea4399d297abda7419a330239842d715.programs_sqlite_hash"` = '"6097c544f012fc21f8cff9a6305ebab335d148e6385d7288a612e10c3cc82df0"' ]
 
-    - name: integration test
+    - name: Integration test
       run: nix build --override-input nixpkgs "github:NixOS/nixpkgs?rev=04f574a1c0fde90b51bf68198e2297ca4e7cccf4" .#checks.x86_64-linux.vmtest

--- a/test.nix
+++ b/test.nix
@@ -6,7 +6,13 @@ let
 
   # NixOS module shared between server and client
   sharedModule = {
-    virtualisation.graphics = false;
+    virtualisation = {
+      graphics = false;
+      # jnsgruk suggests these limits
+      cores = 2;
+      memorySize = 5120;
+      diskSize = 10240;
+    };
     programs.command-not-found.enable = true;
     environment.systemPackages = [ pkgs.gnugrep pkgs.coreutils ];
   };


### PR DESCRIPTION
Enabling KVM reduces runtime for the build & test workflow from approx. 7:30 to 3:30.