### PR TITLE
Remove lib.mdDoc

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -3,10 +3,10 @@ with lib;
 let cfg = config.programs-sqlite;
 in {
   options.programs-sqlite = {
-    enable = mkEnableOption (lib.mdDoc "fetching a `programs.sqlite` for `command-not-found`") //
+    enable = mkEnableOption "fetching a `programs.sqlite` for `command-not-found`" //
     {
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         fetch a `programs.sqlite` file matching the current nixpks revision and use it for the
         `command-not-found` hook.
       '';


### PR DESCRIPTION
lib.mdDoc is deprecated in NixOS 24.05 and is removed in NixOS 24.11