### PR TITLE
remove flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,41 +15,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,29 @@
 {
   inputs = {
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
-    utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, utils }:
+  outputs = { self, nixpkgs }:
     let
+      inherit (nixpkgs) lib;
+
+      systems = builtins.attrNames nixpkgs.legacyPackages;
+      commonSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      updaterSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = lib.genAttrs systems;
+      forCommonSystems = lib.genAttrs commonSystems;
+      forUpdaterSystems = lib.genAttrs updaterSystems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+
       # use tools from given pkgs to extract the db from the download
       getDB = pkgs: pkgs.callPackage ./programs-sqlite.nix { inherit (nixpkgs) rev; };
 
@@ -14,27 +32,45 @@
       sharedModule = pass@{ pkgs, ... }: (import ./module.nix { programs-sqlite = (getDB pkgs); }) pass;
     in
 
-    # provide db-package for all archs, but scaper/test only for most common
-    (utils.lib.eachSystem utils.lib.allSystems (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      nixpkgs.lib.recursiveUpdate
-        (nixpkgs.lib.optionalAttrs (builtins.elem system utils.lib.defaultSystems) rec {
-          packages.updater = pkgs.callPackage ./updater.nix {};
-          apps.updater = { type = "app"; program = "${packages.updater}/bin/updater";};
-          devShells.default = with pkgs; mkShell {
+    {
+      # provide db-package for all archs, but scraper/test only where supported
+      packages = forAllSystems (system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          programs-sqlite = getDB pkgs;
+        } // lib.optionalAttrs (builtins.elem system updaterSystems) {
+          updater = pkgs.callPackage ./updater.nix {};
+        });
+
+      apps = forUpdaterSystems (system: {
+        updater = {
+          type = "app";
+          program = "${self.packages.${system}.updater}/bin/updater";
+        };
+      });
+
+      devShells = forCommonSystems (system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = with pkgs; mkShell {
             buildInputs = [ nim nimble nimlsp pinact ];
           };
-          checks.vmtest = import ./test.nix { inherit pkgs; flake = self; };  # nixpkgs must be set to a revision present in the JSON file
-        })
-        {
-          packages.programs-sqlite = getDB pkgs;
-        })
-    ) //
+        });
 
-    # NixOS & Home Manager modules
-    {
+      checks = forUpdaterSystems (system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          # nixpkgs must be set to a revision present in the JSON file
+          vmtest = import ./test.nix { inherit pkgs; flake = self; };
+        });
+
+      # NixOS & Home Manager modules
       nixosModules.programs-sqlite = sharedModule;
       homeModules.programs-sqlite = sharedModule;
     };


### PR DESCRIPTION
Remove flake-utils and express the flake output matrix directly with nixpkgs.lib.genAttrs. This project only needs a small local helper for system attributes, so the extra input hides simple policy and adds lock weight for external consumers.

<img width="1321" height="904" alt="image" src="https://github.com/user-attachments/assets/ec912643-11e1-4f41-9e25-57e0c8adf596" />
